### PR TITLE
RFC: Perfomance improvements & bug fixes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 name = "mora"
 version = "0.1.0"
 edition = "2021"
+rust-version = "1.70"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Rust and Cargo need to be installed to and added to PATH. The instructions can b
 
 # Installation
 
-1. [rust](https://www.rust-lang.org/tools/install) **version > 1.60.0** and associated tools such as cargo are required and assumed to be in PATH.
+1. [rust](https://www.rust-lang.org/tools/install) **version > 1.70.0** and associated tools such as cargo are required and assumed to be in PATH.
 2. Standard tools such as gcc, make, cmake may be needed. 
 
 To install and download the necessary rust packages to run MORA, run the following commands. 

--- a/src/assignment.rs
+++ b/src/assignment.rs
@@ -5,7 +5,7 @@ use std::sync::Mutex;
 use std::sync::mpsc::channel;
 use rand_distr::WeightedAliasIndex;
 
-use rayon::prelude::{IntoParallelIterator, ParallelIterator, IntoParallelRefIterator};
+use rayon::prelude::{ParallelIterator, IntoParallelRefIterator};
 use rayon::slice::ParallelSliceMut;
 
 use crate::cedar::Cedar;
@@ -192,8 +192,8 @@ impl AssignmentMachine {
     //assignment based on probability with weights being the mapping scores
     fn assign_based_on_prob(&mut self, queries: HashMap<usize, Query>) {
         for (name, query) in queries {
-            let mappings:Vec<Mapping> = query.mappings.into_par_iter().collect();
-            let dist  = WeightedAliasIndex::new(mappings.par_iter().map(|mapping| mapping.get_score()).collect()).unwrap();
+            let mappings:Vec<Mapping> = query.mappings.into_iter().collect();
+            let dist  = WeightedAliasIndex::new(mappings.iter().map(|mapping| mapping.get_score()).collect()).unwrap();
             // assign randomly
             let mut rng = thread_rng();
             let chosen = &mappings[dist.sample(&mut rng)];
@@ -227,7 +227,7 @@ pub(crate) fn assign_mappings(cedar: Cedar, score_max_diff: f32, method: String)
     let references = cedar.get_references();
     let mut machine = AssignmentMachine::new(cedar.get_strain_abundance(), queries.len() - cedar.get_unmapping_reads());
 
-    println!("performing assignment of quries\n");
+    println!("performing assignment of queries\n");
 
     //initial assignment
     queries = machine.initial_assignment(queries);
@@ -293,7 +293,7 @@ fn try_open_up_space(assignments: &HashMap<usize, HashSet<usize>>, machine: &Ass
 
     // sort the keys from smallest to largest
     let mut keys: Vec<&usize> = assignments.keys().collect();
-    keys.par_sort_by(|a, b| a.cmp(b));
+    keys.sort_by(|a, b| a.cmp(b));
 
     // try find a query that can be moved
     for key in &keys {

--- a/src/assignment.rs
+++ b/src/assignment.rs
@@ -133,46 +133,66 @@ impl AssignmentMachine {
         queries
     }
 
-    fn compute_candidate_moves(&self, original_queries: &HashMap<usize, Query>)
-        -> HashMap<usize, VecDeque<CandidateMove>>
+    fn compute_candidate_moves(
+        &self,
+        original_queries: &HashMap<usize, Query>,
+        leftovers: &HashMap<usize, Query>
+    ) -> HashMap<usize, VecDeque<CandidateMove>>
     {
-        let mut candidates = HashMap::new();
+        let mut max_thresholds: HashMap<usize, f32> = HashMap::new();
+        for query in leftovers.values() {
+            let total = query.get_total_score();
 
-        for (ref_id, bins) in &self.assignments {
+            for mapping in &query.mappings {
+                let new_threshold = mapping.get_score() / total;
+                let cur_threshold = max_thresholds
+                    .entry(mapping.get_reference_id())
+                    .or_insert(f32::NEG_INFINITY);
+
+                if new_threshold > *cur_threshold {
+                    *cur_threshold = new_threshold;
+                }
+            }
+        }
+
+        let mut candidates = HashMap::new();
+        for (&ref_id, &threshold_limit) in &max_thresholds {
+            let bins = match self.assignments.get(&ref_id) {
+                Some(b) => b,
+                None => continue
+            };
             let mut list = Vec::new();
+
             for (score, incumbents) in bins {
                 for inc_id in incumbents {
                     let inc = &original_queries[inc_id];
                     let total_score = inc.get_total_score();
-                    let mut best: Option<(f32, usize, usize)> = None;
 
-                    for m in &inc.mappings {
-                        let alt_ref_id = m.get_reference_id();
+                    for mapping in &inc.mappings {
+                        let alt_ref_id = mapping.get_reference_id();
 
-                        if alt_ref_id != *ref_id && self.has_space(&alt_ref_id) {
-                            let cost = 2.0 * (*score as f32) / total_score - m.get_score() / total_score;
+                        if alt_ref_id != ref_id && self.has_space(&alt_ref_id) {
+                            let cost = 2.0 * (*score as f32) / total_score
+                                - mapping.get_score() / total_score;
 
-                            if best.is_none_or(|(c, _, _)| cost < c) {
-                                best = Some((cost, alt_ref_id, m.get_score() as usize));
+                            if cost < threshold_limit {
+                                list.push(CandidateMove {
+                                    cost,
+                                    incumbent_id: *inc_id,
+                                    incumbent_score: *score,
+                                    alt_ref_id,
+                                    alt_score: mapping.get_score() as usize
+                                })
                             }
                         }
                     }
-
-                    if let Some((cost, alt_ref_id, alt_score)) = best {
-                        list.push(
-                            CandidateMove {
-                                cost,
-                                incumbent_id: *inc_id,
-                                incumbent_score: *score,
-                                alt_ref_id,
-                                alt_score
-                            }
-                        )
-                    }
                 }
             }
-            list.sort_by(|a, b| a.cost.partial_cmp(&b.cost).unwrap());
-            candidates.insert(*ref_id, VecDeque::from(list));
+
+            if !list.is_empty() {
+                list.sort_by(|a, b| a.cost.partial_cmp(&b.cost).unwrap());
+                candidates.insert(ref_id, VecDeque::from(list));
+            }
         }
 
         candidates
@@ -278,7 +298,7 @@ impl AssignmentMachine {
         let leftover_queries = if queries.is_empty() {
             HashMap::new()
         } else {
-            let mut candidates = self.compute_candidate_moves(original_queries);
+            let mut candidates = self.compute_candidate_moves(original_queries, &queries);
             self.place_leftovers(&queries, &mut candidates)
         };
         

--- a/src/assignment.rs
+++ b/src/assignment.rs
@@ -292,8 +292,6 @@ impl AssignmentMachine {
         }
         println!("queries have been mapped to the best possible reference. left overs: {}", queries.len());
 
-        let leftover_phase_start = std::time::Instant::now();
-        
         // assignment of the left overs by tring to open up space
         let leftover_queries = if queries.is_empty() {
             HashMap::new()
@@ -302,7 +300,6 @@ impl AssignmentMachine {
             self.place_leftovers(&queries, &mut candidates)
         };
         
-        eprintln!("leftover-phase-seconds: {:.3}", leftover_phase_start.elapsed().as_secs_f64());
         println!("cannot move: {}", leftover_queries.len());
 
         //assign the queries that cannot be mapped based on what method was specified. Default mode is none

--- a/src/assignment.rs
+++ b/src/assignment.rs
@@ -265,7 +265,7 @@ impl AssignmentMachine {
         None
     }
 
-    //assignment based on abudancies
+    //assignment based on abundances
     fn assign_based_on_abundance(&mut self, mut queries: HashMap<usize, Query>, original_queries: &HashMap<usize, Query>, method: String) {
         //create score bins
         let mut score_bins = HashMap::new();
@@ -292,7 +292,7 @@ impl AssignmentMachine {
         }
         println!("queries have been mapped to the best possible reference. left overs: {}", queries.len());
 
-        // assignment of the left overs by tring to open up space
+        // assignment of the left overs by trying to open up space
         let leftover_queries = if queries.is_empty() {
             HashMap::new()
         } else {
@@ -352,7 +352,7 @@ pub(crate) fn assign_mappings(cedar: Cedar, score_max_diff: f32, method: String)
     //initial assignment
     queries = machine.initial_assignment(queries);
 
-    println!("intial assignment done. query length: {}", queries.len());
+    println!("initial assignment done. query length: {}", queries.len());
     
     //secondary assignment
     queries = machine.secondary_assignment(queries, score_max_diff);

--- a/src/assignment.rs
+++ b/src/assignment.rs
@@ -1,11 +1,8 @@
-use std::collections::{HashMap, HashSet};
+use std::collections::{HashMap, HashSet, VecDeque};
 use std::fs::File;
 use std::io::Write;
-use std::sync::Mutex;
-use std::sync::mpsc::channel;
 use rand_distr::WeightedAliasIndex;
 
-use rayon::prelude::{ParallelIterator, IntoParallelRefIterator};
 use rayon::slice::ParallelSliceMut;
 
 use crate::cedar::Cedar;
@@ -14,6 +11,18 @@ use rand::prelude::*;
 
 mod get_taxonomy;
 use get_taxonomy::tax_main;
+
+/*
+    Candidate move for an incumbent to make room on a reference
+ */
+struct CandidateMove {
+    cost: f32,
+    incumbent_id: usize,
+    incumbent_score: usize,
+    alt_ref_id: usize,
+    alt_score: usize
+}
+
 /*
     abundance: <ref_id, estimated abundance from cedar>
     current_abundance: <ref_id, current abundance>
@@ -73,45 +82,167 @@ impl AssignmentMachine {
     }
 
     // initial assignment of unique mapping queries or unmapped queries
-    fn initial_assignment(&mut self, queries: HashMap<usize, Query>) -> HashMap<usize, Query> {
-        let mut updated_queries = queries.clone(); 
-
+    fn initial_assignment(&mut self, mut queries: HashMap<usize, Query>) -> HashMap<usize, Query> {
         let mut unique_mapping_queries = 0;
         let mut unmapped_queries = 0;
+        let mut to_remove = Vec::new();
         
         println!("total query_size = {}", self.query_size);
-        for (query_id, query) in queries {
-            let maps: Vec<Mapping> = query.mappings.into_iter().collect();
+        for (query_id, query) in &queries {
+            if query.mappings.is_empty() {
+                unmapped_queries += 1;
 
-            if {maps.len() == 1} || check_if_read_is_uniquely_mapping(&maps) {
+                self.add_assignment(*query_id, usize::MAX, 0);
+                to_remove.push(*query_id)
+            } else if check_if_read_is_uniquely_mapping(&query.mappings) {
                 unique_mapping_queries += 1;
 
-                updated_queries.remove(&query_id);
-                self.add_assignment(query_id, maps[0].get_reference_id(), 1000);
-            } else if maps.len() == 0 {
-                unmapped_queries += 1;
-                updated_queries.remove(&query_id);
-                self.add_assignment(query_id, usize::MAX, 0);
+                let ref_id = query.mappings.iter().next().unwrap().get_reference_id();
+                self.add_assignment(*query_id, ref_id, 1000);
+                to_remove.push(*query_id)
             }
-
         }
+
+        for id in to_remove {
+            queries.remove(&id);
+        }
+
         println!("unique mapping queries: {}, unmapped queries: {}, current assigned length: {}", unique_mapping_queries, unmapped_queries, self.output_assignments.len());
-        updated_queries
+
+        queries
     }
 
     // secondary assignment of queries whose best mapping is a lot better than the secondary mappings
-    fn secondary_assignment(&mut self, queries: HashMap<usize, Query>, score_max_diff: f32) -> HashMap<usize, Query>{
-        let mut updated_queries = queries.clone();
+    fn secondary_assignment(&mut self, mut queries: HashMap<usize, Query>, score_max_diff: f32) -> HashMap<usize, Query>{
+        let mut to_remove = Vec::new();
+
         for (query_id, query) in &queries {
             let (ref_id, score) = assign_best(query, &self, score_max_diff);
             if ref_id != usize::MAX - 1 {
-                updated_queries.remove(query_id);
+                to_remove.push(*query_id);
                 if self.has_space(&ref_id) {
                     self.add_assignment(*query_id, ref_id, score as usize);
                 }
             }
         }
-        updated_queries
+
+        for id in to_remove {
+            queries.remove(&id);
+        }
+
+        queries
+    }
+
+    fn compute_candidate_moves(&self, original_queries: &HashMap<usize, Query>)
+        -> HashMap<usize, VecDeque<CandidateMove>>
+    {
+        let mut candidates = HashMap::new();
+
+        for (ref_id, bins) in &self.assignments {
+            let mut list = Vec::new();
+            for (score, incumbents) in bins {
+                for inc_id in incumbents {
+                    let inc = &original_queries[inc_id];
+                    let total_score = inc.get_total_score();
+                    let mut best: Option<(f32, usize, usize)> = None;
+
+                    for m in &inc.mappings {
+                        let alt_ref_id = m.get_reference_id();
+
+                        if alt_ref_id != *ref_id && self.has_space(&alt_ref_id) {
+                            let cost = 2.0 * (*score as f32) / total_score - m.get_score() / total_score;
+
+                            if best.is_none_or(|(c, _, _)| cost < c) {
+                                best = Some((cost, alt_ref_id, m.get_score() as usize));
+                            }
+                        }
+                    }
+
+                    if let Some((cost, alt_ref_id, alt_score)) = best {
+                        list.push(
+                            CandidateMove {
+                                cost,
+                                incumbent_id: *inc_id,
+                                incumbent_score: *score,
+                                alt_ref_id,
+                                alt_score
+                            }
+                        )
+                    }
+                }
+            }
+            list.sort_by(|a, b| a.cost.partial_cmp(&b.cost).unwrap());
+            candidates.insert(*ref_id, VecDeque::from(list));
+        }
+
+        candidates
+    }
+
+    fn place_leftovers(&mut self, leftovers: &HashMap<usize, Query>,
+        candidates: &mut HashMap<usize, VecDeque<CandidateMove>>)
+        -> HashMap<usize, Query>
+    {
+        let mut unplaced = HashMap::new();
+
+        let mut leftover_ids: Vec<usize> = leftovers.keys().cloned().collect();
+        leftover_ids.sort_by(|a, b| {
+            leftovers[b].get_best_mappings().1
+                .partial_cmp(&leftovers[a].get_best_mappings().1).unwrap()
+        });
+
+        for query_id in leftover_ids {
+            let total_score = leftovers[&query_id].get_total_score();
+            let mut placed = false;
+
+            for mapping in leftovers[&query_id].sort_mappings() {
+                let target = mapping.get_reference_id();
+                let threshold = mapping.get_score() / total_score;
+
+                let chosen = match candidates.get_mut(&target) {
+                    Some(queue) => self.take_valid_move(queue, target, threshold),
+                    None => continue
+                };
+
+                if let Some(c) = chosen {
+                    self.remove_assignment(target, c.incumbent_id, c.incumbent_score);
+                    self.add_assignment(c.incumbent_id, c.alt_ref_id, c.alt_score);
+                    self.add_assignment(query_id, target, mapping.get_score() as usize);
+                    placed = true;
+                    break;
+                }
+            }
+
+            if !placed {
+                unplaced.insert(query_id, leftovers[&query_id].clone());
+            }
+        }
+
+        unplaced
+    }
+
+    fn take_valid_move(&self, queue: &mut VecDeque<CandidateMove>, target: usize, threshold: f32)
+        -> Option<CandidateMove>
+    {
+        while !queue.is_empty() {
+            if queue[0].cost >= threshold {
+                return None;
+            }
+
+            let (inc_id, inc_score, alt_ref_id) = (
+                queue[0].incumbent_id, queue[0].incumbent_score, queue[0].alt_ref_id
+            );
+
+            let incumbent_here = self.assignments.get(&target)
+                .and_then(|b| b.get(&inc_score))
+                .is_some_and(|s| s.contains(&inc_id));
+
+            if incumbent_here && self.has_space(&alt_ref_id) {
+                return queue.pop_front()
+            }
+            queue.pop_front();
+        }
+
+        None
     }
 
     //assignment based on abudancies
@@ -140,52 +271,25 @@ impl AssignmentMachine {
             }
         }
         println!("queries have been mapped to the best possible reference. left overs: {}", queries.len());
+
+        let leftover_phase_start = std::time::Instant::now();
         
         // assignment of the left overs by tring to open up space
-        let cannot_move = Mutex::new(0);
-        let left_over_queries = Mutex::new(HashMap::new());
-        if queries.len() != 0 {
-            let (sender, receiver) = channel();
-
-            queries.par_iter().for_each_with(sender, |s, (query_id, query)|{
-                let ordered_mappings = query.sort_mappings();
-                let total_score = query.get_total_score();
-                //check if something can be moved from the reference that the mapping is mapped to
-                let mut moved = false;
-                for map in ordered_mappings {
-                    let new_score = map.get_score();
-                    let new_normalized_score = map.get_score() / total_score;
-                    let (q_moved, id_of_moved, re_assigned_ref, original_score, re_assigned_score) = try_open_up_space(&self.assignments[&map.get_reference_id()], self, &map.get_reference_id(), original_queries, new_normalized_score);
-                    if q_moved {
-                        s.send((map.get_reference_id(), id_of_moved, original_score, re_assigned_ref, re_assigned_score, query_id, map.get_reference_id(), new_score as usize)).ok();
-                        moved = true;
-                        break;
-                    }
-                }
-                if !moved {
-                    let mut locked = cannot_move.lock().unwrap();
-                    *locked += 1;
-                    let mut left_over_queries_locked = left_over_queries.lock().unwrap();
-                    left_over_queries_locked.insert(*query_id, query.clone());
-                }
-            });
-
-            let mut res: Vec<_> = receiver.iter().collect();
-            res.iter_mut().for_each(|x| {
-                let (old_ref_id, id_of_moved, original_score, new_ref_id, new_score, 
-                    query_id, map_ref_id, map_score) = x;
-                self.remove_assignment(*old_ref_id, *id_of_moved, *original_score);
-                self.add_assignment(*id_of_moved, *new_ref_id, *new_score);
-                self.add_assignment(**query_id, *map_ref_id, *map_score);
-            });
-        }
-        println!("cannot move: {}", cannot_move.into_inner().unwrap());
+        let leftover_queries = if queries.is_empty() {
+            HashMap::new()
+        } else {
+            let mut candidates = self.compute_candidate_moves(original_queries);
+            self.place_leftovers(&queries, &mut candidates)
+        };
+        
+        eprintln!("leftover-phase-seconds: {:.3}", leftover_phase_start.elapsed().as_secs_f64());
+        println!("cannot move: {}", leftover_queries.len());
 
         //assign the queries that cannot be mapped based on what method was specified. Default mode is none
         if method == "none" {
-            self.leave_left_overs(left_over_queries.into_inner().unwrap());
+            self.leave_left_overs(leftover_queries);
         } else {
-            self.assign_based_on_prob(left_over_queries.into_inner().unwrap());
+            self.assign_based_on_prob(leftover_queries);
         }
     }
 
@@ -211,14 +315,13 @@ impl AssignmentMachine {
 
 
 // helper to check if read is uniquely mapping
-fn check_if_read_is_uniquely_mapping(maps: &Vec<Mapping>) -> bool {
-    let reference_id = maps[0].get_reference_id();
-    for map in maps {
-        if map.get_reference_id() != reference_id {
-            return false;
-        }
-    }
-    return true;
+fn check_if_read_is_uniquely_mapping(mappings: &HashSet<Mapping>) -> bool {
+    let mut it = mappings.iter();
+    let first = match it.next() {
+        Some(m) => m.get_reference_id(),
+        None => return false
+    };
+    it.all(|m| m.get_reference_id() == first)
 }
 
 // assign each mapping to a unique reference based on their mapping scores and the predicted abundance levels
@@ -240,7 +343,7 @@ pub(crate) fn assign_mappings(cedar: Cedar, score_max_diff: f32, method: String)
     println!("second assignment done. query length: {}", queries.len());
 
     //assignment of the rest of the queries based on abundancies
-    machine.assign_based_on_abundance(queries, &cedar.get_queries(), method);
+    machine.assign_based_on_abundance(queries, &cedar.queries, method);
 
     println!("final assignment done. output length: {}", machine.output_assignments.len());
 
@@ -272,46 +375,6 @@ fn assign_best(query: &Query, machine: &AssignmentMachine, score_max_diff: f32) 
     } else {
         (usize::MAX - 1, 0.0)
     }
-}
-
-/*
-    assignemnts: <score, query_name>
-    ref_id: the reference that we are trying to open up space in 
-    new_normalized_score: the score for the read we are trying to make space for
-
-    output: 
-        - if it has been moved
-        - id of query that has been moved
-        - id of reference query was moved to
-        - original mapping score
-        - new mapping score
-*/
-fn try_open_up_space(assignments: &HashMap<usize, HashSet<usize>>, machine: &AssignmentMachine, ref_id: &usize, queries: &HashMap<usize, Query>, new_normalized_score: f32) -> (bool, usize, usize, usize, usize) {
-    if assignments.len() == 0 {
-        return (false, 0, 0, 0, 0);
-    }
-
-    // sort the keys from smallest to largest
-    let mut keys: Vec<&usize> = assignments.keys().collect();
-    keys.sort_by(|a, b| a.cmp(b));
-
-    // try find a query that can be moved
-    for key in &keys {
-        for query_id in assignments.get(key).unwrap() {
-            let query = &queries[query_id];
-            let total_score = query.get_total_score();
-            // try assign the query to somewhere else
-            for mapping in &query.mappings {
-                let re_assigned_ref_id = &mapping.get_reference_id();
-                if re_assigned_ref_id != ref_id && machine.has_space(re_assigned_ref_id) {
-                    if (**key as f32)/total_score - mapping.get_score()/total_score  <  new_normalized_score - (**key as f32)/total_score {
-                        return (true, *query_id, *re_assigned_ref_id, **key, mapping.get_score() as usize);
-                    }
-                }
-            }
-        }
-    }
-    (false, 0, 0, 0, 0)
 }
 
 // write the output into a file in the following way: query_name    reference_name

--- a/src/cedar.rs
+++ b/src/cedar.rs
@@ -489,7 +489,7 @@ impl Cedar {
 
     // outputs file with the references and their estimated abundancies
     pub(crate) fn serialize_simple(&mut self, output_filename: String) {
-        println!("Writing abundanceies into the file: {}", &output_filename);
+        println!("Writing abundances into the file: {}", &output_filename);
 
         let mut output = File::create(output_filename).unwrap();
         for i in 0..self.strain_abundance.len(){

--- a/src/cedar.rs
+++ b/src/cedar.rs
@@ -191,7 +191,7 @@ impl Cedar {
             self.strain_abundance.insert(*key, 0.0);
         }
 
-        // constucting coverage bins;
+        // constructing coverage bins;
         let (sender, receiver) = channel();
 
         (0..self.references.len()).into_par_iter().for_each_with(sender, |s, index| {
@@ -344,7 +344,7 @@ impl Cedar {
 
             // end of set cover input preparation
             // run set_cover algorithm over the lists of refs and eqs in ref2_eqset
-            // as we are givng sets and weights and not &sets and &weights, they are lost after greedy_set_cover finishes
+            // as we are giving sets and weights and not &sets and &weights, they are lost after greedy_set_cover finishes
             let final_covering = greedy_set_cover(sets, weights, unique_element_count);
 
             // put the list of minimum # of references that can cover all eqs in remainingRefs
@@ -442,7 +442,7 @@ impl Cedar {
             });
 
             // E Step
-            // normalize strain probabilities using the denum : p(s) = (count(s)/total_read_cnt)
+            // normalize strain probabilities using the denom : p(s) = (count(s)/total_read_cnt)
             converged = true;
             let mut max_diff = 0.0;
 
@@ -487,7 +487,7 @@ impl Cedar {
         std::mem::swap(&mut self.strain_abundance, &mut output_map);
     }
 
-    // outputs file with the references and their estimated abundancies
+    // outputs file with the references and their estimated abundances
     pub(crate) fn serialize_simple(&mut self, output_filename: String) {
         println!("Writing abundances into the file: {}", &output_filename);
 

--- a/src/cedar/readers.rs
+++ b/src/cedar/readers.rs
@@ -175,17 +175,19 @@ fn analyze_alignments(mut f: Reader, method: String) -> (HashMap<usize, Query>, 
         let record = r.unwrap(); 
         let reference_id = record.tid();
         let query_name = str::from_utf8(record.qname()).unwrap();
-        let mut score:i32 = 0;
+        let mut score:i32;
         let position = record.pos();
         let paired = record.is_paired();
         let query_len = record.seq_len() as u32;
         match record.aux(b"AS") {
-            Ok(value) => {
-                if let Aux::U8(v) = value { score = v as i32; }
-                if let Aux::I8(v) = value { score = v as i32; }
-            } Err(_e) => {
-                score = 0;
-            }
+            Ok(Aux::U8(v))    => score = v as i32,
+            Ok(Aux::I8(v))    => score = v as i32,
+            Ok(Aux::U16(v))    => score = v as i32,
+            Ok(Aux::I16(v))    => score = v as i32,
+            Ok(Aux::U32(v))    => score = v as i32,
+            Ok(Aux::I32(v))    => score = v as i32,
+            Ok(Aux::Float(v)) => score = (v * 100.0).round() as i32,
+            _                 => score = 0,
         }
         if method == "bowtie2" { // This is where you add different ways to interperet AS:i scores for different intial aligners
             score += 160;
@@ -206,7 +208,12 @@ fn analyze_alignments(mut f: Reader, method: String) -> (HashMap<usize, Query>, 
             current_name = query_name.to_string();
             current_query.add_mapping(mapping);
         }
-    }    
+    }
+
+    if query_id != 0 {
+        queries.insert(query_id, current_query);
+        query_id_2_names.insert(query_id, current_name.to_string());
+    }
 
     (queries, query_id_2_names)
 }

--- a/src/cedar/readers.rs
+++ b/src/cedar/readers.rs
@@ -96,8 +96,8 @@ impl Query {
     }
 
     pub(crate) fn sort_mappings(&self) -> Vec<&Mapping> {
-        let mut ordered_vec: Vec<&Mapping> = self.mappings.par_iter().collect();
-        ordered_vec.par_sort_by(|a, b| b.get_score().partial_cmp(&a.get_score()).unwrap());
+        let mut ordered_vec: Vec<&Mapping> = self.mappings.iter().collect();
+        ordered_vec.sort_by(|a, b| b.get_score().partial_cmp(&a.get_score()).unwrap());
         ordered_vec
     }
 }

--- a/src/cedar/readers.rs
+++ b/src/cedar/readers.rs
@@ -189,7 +189,7 @@ fn analyze_alignments(mut f: Reader, method: String) -> (HashMap<usize, Query>, 
             Ok(Aux::Float(v)) => score = (v * 100.0).round() as i32,
             _                 => score = 0,
         }
-        if method == "bowtie2" { // This is where you add different ways to interperet AS:i scores for different intial aligners
+        if method == "bowtie2" { // This is where you add different ways to interpret AS:i scores for different initial aligners
             score += 160;
         }
         if score <= 0 { // I assume that score = 0 means that it doesn't map


### PR DESCRIPTION
Hi @AfZheng126, 

I've been struggling with issue #9 where some bam files will take days to complete. So I took a crack at trying to speed things up. Now a bam that takes >4 days with 32 cores takes <4 mins with 8 cores.
However, I'd love to have you review these changes and give some feedback.

The main bottleneck seemed to be the leftover resolution stage. When I was looking at the code I think I managed to fix another issue where it seemed that potential leftover moves were collected in parallel, but actually taking those moves occurred after the parallel loop. However these moves were taken without checking again whether those moves were still valid (checking if a query to be moved was still at the expected reference, and checking if the receiving reference still had space). In the new version, it seems that not very many leftovers are being placed, but in the original it's possible to assign to many leftover queries to references (push them beyond capacity).
Now, the code just looks once (not in parallel) for candidate moves, and taking those moves comes with some validity checking.

I've also removed some nested parallelism and reduced some data clones which seems to reduce memory usage. Also there are some various other fixes that I came across.
Happy to answer any questions or make suggested fixes.